### PR TITLE
Update Context addContext() implementation

### DIFF
--- a/src/Twig/Context.php
+++ b/src/Twig/Context.php
@@ -39,7 +39,7 @@ class Context implements Countable, IteratorAggregate
      */
     public function addContext(array $context)
     {
-        $this->context = array_merge_recursive($this->context, $context);
+        $this->context = array_replace_recursive($this->context, $context);
     }
 
     /**

--- a/testing/tests/Twig/ContextTest.php
+++ b/testing/tests/Twig/ContextTest.php
@@ -70,4 +70,52 @@ class ContextTest extends PHPUnit_Framework_TestCase
         $this->assertSame(null, $context->get('test4'));
         $this->assertSame($raw, $context->get());
     }
+
+    public function testMergeReplace()
+    {
+        $context = new Context([
+            'test1' => 'value1',
+            'test2' => ['test3' => 'value3']
+        ]);
+
+        $context->addContext([
+            'test1' => 'value2',
+            'test2' => ['test4' => 'value4']
+        ]);
+
+        $expected = [
+            'test1' => 'value2',
+            'test2' => [
+                'test3' => 'value3',
+                'test4' => 'value4'
+            ]
+        ];
+
+        $this->assertSame($expected, $context->get());
+    }
+
+    /**
+     * Ensure that self-referencing objects do not cause a segfault. This can happen when array_merge_recursive
+     * is used to merge context.
+     */
+    public function testMergeSelfReferencingObjects()
+    {
+        $a = new \stdClass();
+
+        $a->a = $a;
+
+        $context = new Context([
+            'a' => $a
+        ]);
+
+        $context->addContext([
+            'a' => $a
+        ]);
+
+        $expected = [
+            'a' => $a
+        ];
+
+        $this->assertSame($expected, $context->get());
+    }
 }


### PR DESCRIPTION
Discovered an annoying bug while using the `Context` this evening.

- Previous use of `array_merge_recursive()` caused problems when the context contained conflicting objects (same key string value) with self-referencing links (Doctrine objects, for example) because it doesn't properly ignore non-array leaf values in the array.
```php
$a = new stdClass();
$a->a = $a;

// middleware
$context = new Context([
    'a' => $a
]);

// controller
$context->addContext(['a' => $a]);

// expected result
['a' => $a]
// actual result
// segfault or infinite loop, depending on system
```
- Previous use of `array_merge_recursive()` caused unexpected context output when added context key conflicted with an existing key.
```php
// middleware
$context = new Context([
    'a' => 'b'
]);

// controller
$context->addContext([
    'a' => 'c'
]);

// render
$context->get();

// expected result
['a' => 'c']
// actual result
['a' => ['b', 'c']]
```
```twig
<p>{{ a }}</p>

{# expected result #}
<p>c</p>
{# actual result #}
<p></p> {# (non string) #}
```
- Changed use of `array_merge_recursive()` with `array_replace_recursive()` which maintains expected functionality, but handles conflicts differently.
- Added tests to ensure edge case is handled.