### PR TITLE
sane default for cookie path

### DIFF
--- a/configuration/panthor.yml
+++ b/configuration/panthor.yml
@@ -23,7 +23,7 @@ parameters:
     cookie.settings:
         expires: 0
         maxAge: 0
-        path: ''
+        path: '/'
         domain: ''
         secure: false
         httpOnly: false


### PR DESCRIPTION
Currently the default cookie path in configuration is an empty string. If the set-cookie header is passed back with an empty path the browser will interpret the path of the cookie as the current page. This will lead to multiple cookies with the same name but different path's. While easily fixable by setting:

```
cookie.settings:
         path: '/'
```

Setting `/` as the default aligns to developer's expected cookie behaviour. 