### PR TITLE
Fix failing tests

### DIFF
--- a/tests/ErrorHandling/ContentHandler/HTMLTemplateContentHandlerTest.php
+++ b/tests/ErrorHandling/ContentHandler/HTMLTemplateContentHandlerTest.php
@@ -45,14 +45,31 @@ class HTMLTemplateContentHandlerTest extends PHPUnit_Framework_TestCase
 
         $response = $handler->handleNotFound($this->request, $this->response);
 
-        $expected = <<<HTML
-HTTP/1.1 404 Not Found
-Content-Type: text/html
+        $expectedHTTPVersion = '1.1';
+        $actualHTTPVersion = $response->getProtocolVersion();
 
-<html>derp</html>
-HTML;
+        $expectedStatusCode = 404;
+        $actualStatusCode = $response->getStatusCode();
 
-        $this->assertSame($expected, (string) $response);
+        $expectedReasonPhrase = 'Not Found';
+        $actualReasonPhrase = $response->getReasonPhrase();
+
+        $expectedHeaders = [
+            'Content-Type' => [
+                'text/html'
+            ]
+        ];
+        $actualHeaders = $response->getHeaders();
+
+        $expectedBody = '<html>derp</html>';
+        $actualBody = $response->getBody();
+        $actualBody->rewind();
+
+        $this->assertSame($expectedHTTPVersion, $actualHTTPVersion);
+        $this->assertSame($expectedStatusCode, $actualStatusCode);
+        $this->assertSame($expectedReasonPhrase, $actualReasonPhrase);
+        $this->assertSame($expectedHeaders, $actualHeaders);
+        $this->assertSame($expectedBody, $actualBody->getContents());
     }
 
     public function testNotAllowed()
@@ -69,14 +86,31 @@ HTML;
 
         $response = $handler->handleNotAllowed($this->request, $this->response, ['PATCH', 'STEVE']);
 
-        $expected = <<<HTML
-HTTP/1.1 405 Method Not Allowed
-Content-Type: text/html
+        $expectedHTTPVersion = '1.1';
+        $actualHTTPVersion = $response->getProtocolVersion();
 
-<html>derp</html>
-HTML;
+        $expectedStatusCode = 405;
+        $actualStatusCode = $response->getStatusCode();
 
-        $this->assertSame($expected, (string) $response);
+        $expectedReasonPhrase = 'Method Not Allowed';
+        $actualReasonPhrase = $response->getReasonPhrase();
+
+        $expectedHeaders = [
+            'Content-Type' => [
+                'text/html'
+            ]
+        ];
+        $actualHeaders = $response->getHeaders();
+
+        $expectedBody = '<html>derp</html>';
+        $actualBody = $response->getBody();
+        $actualBody->rewind();
+
+        $this->assertSame($expectedHTTPVersion, $actualHTTPVersion);
+        $this->assertSame($expectedStatusCode, $actualStatusCode);
+        $this->assertSame($expectedReasonPhrase, $actualReasonPhrase);
+        $this->assertSame($expectedHeaders, $actualHeaders);
+        $this->assertSame($expectedBody, $actualBody->getContents());
     }
 
     public function testNotAllowedSets200StatusIfOptionsRequest()
@@ -91,18 +125,36 @@ HTML;
                 'allowed_methods' => 'PATCH, STEVE'
             ])
             ->andReturn('<html>derp</html>');
+
         $handler = new HTMLTemplateContentHandler($this->template);
 
         $response = $handler->handleNotAllowed($this->request, $this->response, ['PATCH', 'STEVE']);
 
-        $expected = <<<HTML
-HTTP/1.1 200 OK
-Content-Type: text/html
+        $expectedHTTPVersion = '1.1';
+        $actualHTTPVersion = $response->getProtocolVersion();
 
-<html>derp</html>
-HTML;
+        $expectedStatusCode = 200;
+        $actualStatusCode = $response->getStatusCode();
 
-        $this->assertSame($expected, (string) $response);
+        $expectedReasonPhrase = 'OK';
+        $actualReasonPhrase = $response->getReasonPhrase();
+
+        $expectedHeaders = [
+            'Content-Type' => [
+                'text/html'
+            ]
+        ];
+        $actualHeaders = $response->getHeaders();
+
+        $expectedBody = '<html>derp</html>';
+        $actualBody = $response->getBody();
+        $actualBody->rewind();
+
+        $this->assertSame($expectedHTTPVersion, $actualHTTPVersion);
+        $this->assertSame($expectedStatusCode, $actualStatusCode);
+        $this->assertSame($expectedReasonPhrase, $actualReasonPhrase);
+        $this->assertSame($expectedHeaders, $actualHeaders);
+        $this->assertSame($expectedBody, $actualBody->getContents());
     }
 
     public function testHandleException()
@@ -122,14 +174,31 @@ HTML;
         $handler = new HTMLTemplateContentHandler($this->template);
         $response = $handler->handleException($this->request, $this->response, $ex);
 
-        $expected = <<<HTML
-HTTP/1.1 500 Internal Server Error
-Content-Type: text/html
+        $expectedHTTPVersion = '1.1';
+        $actualHTTPVersion = $response->getProtocolVersion();
 
-<html>error</html>
-HTML;
+        $expectedStatusCode = 500;
+        $actualStatusCode = $response->getStatusCode();
 
-        $this->assertSame($expected, (string) $response);
+        $expectedReasonPhrase = 'Internal Server Error';
+        $actualReasonPhrase = $response->getReasonPhrase();
+
+        $expectedHeaders = [
+            'Content-Type' => [
+                'text/html'
+            ]
+        ];
+        $actualHeaders = $response->getHeaders();
+
+        $expectedBody = '<html>error</html>';
+        $actualBody = $response->getBody();
+        $actualBody->rewind();
+
+        $this->assertSame($expectedHTTPVersion, $actualHTTPVersion);
+        $this->assertSame($expectedStatusCode, $actualStatusCode);
+        $this->assertSame($expectedReasonPhrase, $actualReasonPhrase);
+        $this->assertSame($expectedHeaders, $actualHeaders);
+        $this->assertSame($expectedBody, $actualBody->getContents());
     }
 
     public function testHandleExceptionWithErrorDetails()
@@ -144,20 +213,37 @@ HTML;
         $handler = new HTMLTemplateContentHandler($this->template, true);
         $response = $handler->handleException($this->request, $this->response, $ex);
 
-        $expected = <<<HTML
-HTTP/1.1 500 Internal Server Error
-Content-Type: text/html
+        $expectedHTTPVersion = '1.1';
+        $actualHTTPVersion = $response->getProtocolVersion();
 
-<html>error</html>
-HTML;
+        $expectedStatusCode = 500;
+        $actualStatusCode = $response->getStatusCode();
 
-        $this->assertSame($expected, (string) $response);
+        $expectedReasonPhrase = 'Internal Server Error';
+        $actualReasonPhrase = $response->getReasonPhrase();
+
+        $expectedHeaders = [
+            'Content-Type' => [
+                'text/html'
+            ]
+        ];
+        $actualHeaders = $response->getHeaders();
+
+        $expectedBody = '<html>error</html>';
+        $actualBody = $response->getBody();
+        $actualBody->rewind();
+
+        $this->assertSame($expectedHTTPVersion, $actualHTTPVersion);
+        $this->assertSame($expectedStatusCode, $actualStatusCode);
+        $this->assertSame($expectedReasonPhrase, $actualReasonPhrase);
+        $this->assertSame($expectedHeaders, $actualHeaders);
+        $this->assertSame($expectedBody, $actualBody->getContents());
 
         $captured = $spy();
         $this->assertSame('exception message', $captured['message']);
         $this->assertSame(500, $captured['status']);
         $this->assertSame('E_ERROR', $captured['severity']);
         $this->assertSame($ex, $captured['throwable']);
-        $this->assertContains('ErrorHandling/ContentHandler/HTMLTemplateContentHandlerTest.php:137', $captured['details']);
+        $this->assertContains('ErrorHandling/ContentHandler/HTMLTemplateContentHandlerTest.php:206', $captured['details']);
     }
 }

--- a/tests/ErrorHandling/ContentHandler/HTTPProblemContentHandlerTest.php
+++ b/tests/ErrorHandling/ContentHandler/HTTPProblemContentHandlerTest.php
@@ -30,14 +30,31 @@ class HTTPProblemContentHandlerTest extends PHPUnit_Framework_TestCase
         $handler = new HTTPProblemContentHandler;
         $response = $handler->handleNotFound($this->request, $this->response);
 
-        $expected = <<<HTML
-HTTP/1.1 404 Not Found
-Content-Type: application/problem+json
+        $expectedHTTPVersion = '1.1';
+        $actualHTTPVersion = $response->getProtocolVersion();
 
-{"status":404,"title":"Not Found"}
-HTML;
+        $expectedStatusCode = 404;
+        $actualStatusCode = $response->getStatusCode();
 
-        $this->assertSame($expected, (string) $response);
+        $expectedReasonPhrase = 'Not Found';
+        $actualReasonPhrase = $response->getReasonPhrase();
+
+        $expectedHeaders = [
+            'Content-Type' => [
+                'application/problem+json'
+            ]
+        ];
+        $actualHeaders = $response->getHeaders();
+
+        $expectedBody = '{"status":404,"title":"Not Found"}';
+        $actualBody = $response->getBody();
+        $actualBody->rewind();
+
+        $this->assertSame($expectedHTTPVersion, $actualHTTPVersion);
+        $this->assertSame($expectedStatusCode, $actualStatusCode);
+        $this->assertSame($expectedReasonPhrase, $actualReasonPhrase);
+        $this->assertSame($expectedHeaders, $actualHeaders);
+        $this->assertSame($expectedBody, $actualBody->getContents());
     }
 
     public function testNotAllowed()
@@ -45,14 +62,31 @@ HTML;
         $handler = new HTTPProblemContentHandler;
         $response = $handler->handleNotAllowed($this->request, $this->response, ['PATCH', 'STEVE']);
 
-        $expected = <<<HTML
-HTTP/1.1 405 Method Not Allowed
-Content-Type: application/problem+json
+        $expectedHTTPVersion = '1.1';
+        $actualHTTPVersion = $response->getProtocolVersion();
 
-{"status":405,"title":"Method Not Allowed","detail":"Allowed methods: PATCH, STEVE","allowed_methods":["PATCH","STEVE"]}
-HTML;
+        $expectedStatusCode = 405;
+        $actualStatusCode = $response->getStatusCode();
 
-        $this->assertSame($expected, (string) $response);
+        $expectedReasonPhrase = 'Method Not Allowed';
+        $actualReasonPhrase = $response->getReasonPhrase();
+
+        $expectedHeaders = [
+            'Content-Type' => [
+                'application/problem+json'
+            ]
+        ];
+        $actualHeaders = $response->getHeaders();
+
+        $expectedBody = '{"status":405,"title":"Method Not Allowed","detail":"Allowed methods: PATCH, STEVE","allowed_methods":["PATCH","STEVE"]}';
+        $actualBody = $response->getBody();
+        $actualBody->rewind();
+
+        $this->assertSame($expectedHTTPVersion, $actualHTTPVersion);
+        $this->assertSame($expectedStatusCode, $actualStatusCode);
+        $this->assertSame($expectedReasonPhrase, $actualReasonPhrase);
+        $this->assertSame($expectedHeaders, $actualHeaders);
+        $this->assertSame($expectedBody, $actualBody->getContents());
     }
 
     public function testNotAllowedSets200StatusIfOptionsRequest()
@@ -62,14 +96,31 @@ HTML;
         $handler = new HTTPProblemContentHandler;
         $response = $handler->handleNotAllowed($this->request, $this->response, ['PATCH', 'STEVE']);
 
-        $expected = <<<HTML
-HTTP/1.1 200 OK
-Content-Type: application/problem+json
+        $expectedHTTPVersion = '1.1';
+        $actualHTTPVersion = $response->getProtocolVersion();
 
-{"status":200,"title":"OK","detail":"Allowed methods: PATCH, STEVE","allowed_methods":["PATCH","STEVE"]}
-HTML;
+        $expectedStatusCode = 200;
+        $actualStatusCode = $response->getStatusCode();
 
-        $this->assertSame($expected, (string) $response);
+        $expectedReasonPhrase = 'OK';
+        $actualReasonPhrase = $response->getReasonPhrase();
+
+        $expectedHeaders = [
+            'Content-Type' => [
+                'application/problem+json'
+            ]
+        ];
+        $actualHeaders = $response->getHeaders();
+
+        $expectedBody = '{"status":200,"title":"OK","detail":"Allowed methods: PATCH, STEVE","allowed_methods":["PATCH","STEVE"]}';
+        $actualBody = $response->getBody();
+        $actualBody->rewind();
+
+        $this->assertSame($expectedHTTPVersion, $actualHTTPVersion);
+        $this->assertSame($expectedStatusCode, $actualStatusCode);
+        $this->assertSame($expectedReasonPhrase, $actualReasonPhrase);
+        $this->assertSame($expectedHeaders, $actualHeaders);
+        $this->assertSame($expectedBody, $actualBody->getContents());
     }
 
     public function testHandleException()
@@ -79,14 +130,31 @@ HTML;
         $handler = new HTTPProblemContentHandler;
         $response = $handler->handleException($this->request, $this->response, $ex);
 
-        $expected = <<<HTML
-HTTP/1.1 500 Internal Server Error
-Content-Type: application/problem+json
+        $expectedHTTPVersion = '1.1';
+        $actualHTTPVersion = $response->getProtocolVersion();
 
-{"status":500,"title":"Internal Server Error","detail":"Internal Server Error"}
-HTML;
+        $expectedStatusCode = 500;
+        $actualStatusCode = $response->getStatusCode();
 
-        $this->assertSame($expected, (string) $response);
+        $expectedReasonPhrase = 'Internal Server Error';
+        $actualReasonPhrase = $response->getReasonPhrase();
+
+        $expectedHeaders = [
+            'Content-Type' => [
+                'application/problem+json'
+            ]
+        ];
+        $actualHeaders = $response->getHeaders();
+
+        $expectedBody = '{"status":500,"title":"Internal Server Error","detail":"Internal Server Error"}';
+        $actualBody = $response->getBody();
+        $actualBody->rewind();
+
+        $this->assertSame($expectedHTTPVersion, $actualHTTPVersion);
+        $this->assertSame($expectedStatusCode, $actualStatusCode);
+        $this->assertSame($expectedReasonPhrase, $actualReasonPhrase);
+        $this->assertSame($expectedHeaders, $actualHeaders);
+        $this->assertSame($expectedBody, $actualBody->getContents());
     }
 
     public function testHandleExceptionWithDetails()
@@ -96,13 +164,30 @@ HTML;
         $handler = new HTTPProblemContentHandler(null, true);
         $response = $handler->handleException($this->request, $this->response, $ex);
 
-        $expected = <<<HTML
-HTTP/1.1 500 Internal Server Error
-Content-Type: application/problem+json
-HTML;
+        $expectedHTTPVersion = '1.1';
+        $actualHTTPVersion = $response->getProtocolVersion();
 
-        $rendered = (string) $response;
-        $this->assertContains($expected, $rendered);
+        $expectedStatusCode = 500;
+        $actualStatusCode = $response->getStatusCode();
+
+        $expectedReasonPhrase = 'Internal Server Error';
+        $actualReasonPhrase = $response->getReasonPhrase();
+
+        $expectedHeaders = [
+            'Content-Type' => [
+                'application/problem+json'
+            ]
+        ];
+        $actualHeaders = $response->getHeaders();
+
+        $actualBody = $response->getBody();
+        $actualBody->rewind();
+        $rendered = $actualBody->getContents();
+
+        $this->assertSame($expectedHTTPVersion, $actualHTTPVersion);
+        $this->assertSame($expectedStatusCode, $actualStatusCode);
+        $this->assertSame($expectedReasonPhrase, $actualReasonPhrase);
+        $this->assertSame($expectedHeaders, $actualHeaders);
         $this->assertContains('"detail":"exception message"', $rendered);
         $this->assertContains('"error_details":"ERR ', $rendered);
     }

--- a/tests/ErrorHandling/ContentHandler/JSONContentHandlerTest.php
+++ b/tests/ErrorHandling/ContentHandler/JSONContentHandlerTest.php
@@ -30,14 +30,31 @@ class JSONContentHandlerTest extends PHPUnit_Framework_TestCase
         $handler = new JSONContentHandler;
         $response = $handler->handleNotFound($this->request, $this->response);
 
-        $expected = <<<HTML
-HTTP/1.1 404 Not Found
-Content-Type: application/json
+        $expectedHTTPVersion = '1.1';
+        $actualHTTPVersion = $response->getProtocolVersion();
 
-{"message":"Not Found"}
-HTML;
+        $expectedStatusCode = 404;
+        $actualStatusCode = $response->getStatusCode();
 
-        $this->assertSame($expected, (string) $response);
+        $expectedReasonPhrase = 'Not Found';
+        $actualReasonPhrase = $response->getReasonPhrase();
+
+        $expectedHeaders = [
+            'Content-Type' => [
+                'application/json'
+            ]
+        ];
+        $actualHeaders = $response->getHeaders();
+
+        $expectedBody = '{"message":"Not Found"}';
+        $actualBody = $response->getBody();
+        $actualBody->rewind();
+
+        $this->assertSame($expectedHTTPVersion, $actualHTTPVersion);
+        $this->assertSame($expectedStatusCode, $actualStatusCode);
+        $this->assertSame($expectedReasonPhrase, $actualReasonPhrase);
+        $this->assertSame($expectedHeaders, $actualHeaders);
+        $this->assertSame($expectedBody, $actualBody->getContents());
     }
 
     public function testNotAllowed()
@@ -45,14 +62,31 @@ HTML;
         $handler = new JSONContentHandler;
         $response = $handler->handleNotAllowed($this->request, $this->response, ['PATCH', 'STEVE']);
 
-        $expected = <<<HTML
-HTTP/1.1 405 Method Not Allowed
-Content-Type: application/json
+        $expectedHTTPVersion = '1.1';
+        $actualHTTPVersion = $response->getProtocolVersion();
 
-{"message":"Method not allowed.","allowed_methods":"PATCH, STEVE"}
-HTML;
+        $expectedStatusCode = 405;
+        $actualStatusCode = $response->getStatusCode();
 
-        $this->assertSame($expected, (string) $response);
+        $expectedReasonPhrase = 'Method Not Allowed';
+        $actualReasonPhrase = $response->getReasonPhrase();
+
+        $expectedHeaders = [
+            'Content-Type' => [
+                'application/json'
+            ]
+        ];
+        $actualHeaders = $response->getHeaders();
+
+        $expectedBody = '{"message":"Method not allowed.","allowed_methods":"PATCH, STEVE"}';
+        $actualBody = $response->getBody();
+        $actualBody->rewind();
+
+        $this->assertSame($expectedHTTPVersion, $actualHTTPVersion);
+        $this->assertSame($expectedStatusCode, $actualStatusCode);
+        $this->assertSame($expectedReasonPhrase, $actualReasonPhrase);
+        $this->assertSame($expectedHeaders, $actualHeaders);
+        $this->assertSame($expectedBody, $actualBody->getContents());
     }
 
     public function testNotAllowedSets200StatusIfOptionsRequest()
@@ -62,14 +96,31 @@ HTML;
         $handler = new JSONContentHandler;
         $response = $handler->handleNotAllowed($this->request, $this->response, ['PATCH', 'STEVE']);
 
-        $expected = <<<HTML
-HTTP/1.1 200 OK
-Content-Type: application/json
+        $expectedHTTPVersion = '1.1';
+        $actualHTTPVersion = $response->getProtocolVersion();
 
-{"message":"Method not allowed.","allowed_methods":"PATCH, STEVE"}
-HTML;
+        $expectedStatusCode = 200;
+        $actualStatusCode = $response->getStatusCode();
 
-        $this->assertSame($expected, (string) $response);
+        $expectedReasonPhrase = 'OK';
+        $actualReasonPhrase = $response->getReasonPhrase();
+
+        $expectedHeaders = [
+            'Content-Type' => [
+                'application/json'
+            ]
+        ];
+        $actualHeaders = $response->getHeaders();
+
+        $expectedBody = '{"message":"Method not allowed.","allowed_methods":"PATCH, STEVE"}';
+        $actualBody = $response->getBody();
+        $actualBody->rewind();
+
+        $this->assertSame($expectedHTTPVersion, $actualHTTPVersion);
+        $this->assertSame($expectedStatusCode, $actualStatusCode);
+        $this->assertSame($expectedReasonPhrase, $actualReasonPhrase);
+        $this->assertSame($expectedHeaders, $actualHeaders);
+        $this->assertSame($expectedBody, $actualBody->getContents());
     }
 
     public function testHandleException()
@@ -79,14 +130,31 @@ HTML;
         $handler = new JSONContentHandler;
         $response = $handler->handleException($this->request, $this->response, $ex);
 
-        $expected = <<<HTML
-HTTP/1.1 500 Internal Server Error
-Content-Type: application/json
+        $expectedHTTPVersion = '1.1';
+        $actualHTTPVersion = $response->getProtocolVersion();
 
-{"error":"Application Error"}
-HTML;
+        $expectedStatusCode = 500;
+        $actualStatusCode = $response->getStatusCode();
 
-        $this->assertSame($expected, (string) $response);
+        $expectedReasonPhrase = 'Internal Server Error';
+        $actualReasonPhrase = $response->getReasonPhrase();
+
+        $expectedHeaders = [
+            'Content-Type' => [
+                'application/json'
+            ]
+        ];
+        $actualHeaders = $response->getHeaders();
+
+        $expectedBody = '{"error":"Application Error"}';
+        $actualBody = $response->getBody();
+        $actualBody->rewind();
+
+        $this->assertSame($expectedHTTPVersion, $actualHTTPVersion);
+        $this->assertSame($expectedStatusCode, $actualStatusCode);
+        $this->assertSame($expectedReasonPhrase, $actualReasonPhrase);
+        $this->assertSame($expectedHeaders, $actualHeaders);
+        $this->assertSame($expectedBody, $actualBody->getContents());
     }
 
     public function testHandleExceptionWithErrorDetails()
@@ -96,13 +164,30 @@ HTML;
         $handler = new JSONContentHandler(null, true);
         $response = $handler->handleException($this->request, $this->response, $ex);
 
-        $expected = <<<HTML
-HTTP/1.1 500 Internal Server Error
-Content-Type: application/json
-HTML;
+        $expectedHTTPVersion = '1.1';
+        $actualHTTPVersion = $response->getProtocolVersion();
 
-        $rendered = (string) $response;
-        $this->assertContains($expected, $rendered);
+        $expectedStatusCode = 500;
+        $actualStatusCode = $response->getStatusCode();
+
+        $expectedReasonPhrase = 'Internal Server Error';
+        $actualReasonPhrase = $response->getReasonPhrase();
+
+        $expectedHeaders = [
+            'Content-Type' => [
+                'application/json'
+            ]
+        ];
+        $actualHeaders = $response->getHeaders();
+
+        $actualBody = $response->getBody();
+        $actualBody->rewind();
+        $rendered = $actualBody->getContents();
+
+        $this->assertSame($expectedHTTPVersion, $actualHTTPVersion);
+        $this->assertSame($expectedStatusCode, $actualStatusCode);
+        $this->assertSame($expectedReasonPhrase, $actualReasonPhrase);
+        $this->assertSame($expectedHeaders, $actualHeaders);
         $this->assertContains('"error":"exception message",', $rendered);
         $this->assertContains('"details":"ERR ', $rendered);
     }

--- a/tests/ErrorHandling/ContentHandler/NegotiatingContentHandlerTest.php
+++ b/tests/ErrorHandling/ContentHandler/NegotiatingContentHandlerTest.php
@@ -32,14 +32,31 @@ class NegotiatingContentHandlerTest extends PHPUnit_Framework_TestCase
         $handler = new NegotiatingContentHandler;
         $response = $handler->handleNotFound($this->request, $this->response);
 
-        $expected = <<<HTML
-HTTP/1.1 404 Not Found
-Content-Type: application/json
+        $expectedHTTPVersion = '1.1';
+        $actualHTTPVersion = $response->getProtocolVersion();
 
-{"message":"Not Found"}
-HTML;
+        $expectedStatusCode = 404;
+        $actualStatusCode = $response->getStatusCode();
 
-        $this->assertSame($expected, (string) $response);
+        $expectedReasonPhrase = 'Not Found';
+        $actualReasonPhrase = $response->getReasonPhrase();
+
+        $expectedHeaders = [
+            'Content-Type' => [
+                'application/json'
+            ]
+        ];
+        $actualHeaders = $response->getHeaders();
+
+        $expectedBody = '{"message":"Not Found"}';
+        $actualBody = $response->getBody();
+        $actualBody->rewind();
+
+        $this->assertSame($expectedHTTPVersion, $actualHTTPVersion);
+        $this->assertSame($expectedStatusCode, $actualStatusCode);
+        $this->assertSame($expectedReasonPhrase, $actualReasonPhrase);
+        $this->assertSame($expectedHeaders, $actualHeaders);
+        $this->assertSame($expectedBody, $actualBody->getContents());
     }
 
     public function testNotAllowedWithEmptyListOnlyUsesPlaintext()
@@ -49,15 +66,34 @@ HTML;
         $handler = new NegotiatingContentHandler([]);
         $response = $handler->handleNotAllowed($this->request, $this->response, ['PATCH', 'STEVE']);
 
-        $expected = <<<HTML
-HTTP/1.1 405 Method Not Allowed
-Content-Type: text/plain
+        $expectedHTTPVersion = '1.1';
+        $actualHTTPVersion = $response->getProtocolVersion();
 
+        $expectedStatusCode = 405;
+        $actualStatusCode = $response->getStatusCode();
+
+        $expectedReasonPhrase = 'Method Not Allowed';
+        $actualReasonPhrase = $response->getReasonPhrase();
+
+        $expectedHeaders = [
+            'Content-Type' => [
+                'text/plain'
+            ]
+        ];
+        $actualHeaders = $response->getHeaders();
+
+        $expectedBody = <<<HTML
 Method not allowed.
 Allowed methods: PATCH, STEVE
 HTML;
+        $actualBody = $response->getBody();
+        $actualBody->rewind();
 
-        $this->assertSame($expected, (string) $response);
+        $this->assertSame($expectedHTTPVersion, $actualHTTPVersion);
+        $this->assertSame($expectedStatusCode, $actualStatusCode);
+        $this->assertSame($expectedReasonPhrase, $actualReasonPhrase);
+        $this->assertSame($expectedHeaders, $actualHeaders);
+        $this->assertSame($expectedBody, $actualBody->getContents());
     }
 
     public function testHandleExceptionNoMatchUsesFirstInList()
@@ -72,13 +108,30 @@ HTML;
 
         $response = $handler->handleException($this->request, $this->response, $ex);
 
-        $expected = <<<HTML
-HTTP/1.1 500 Internal Server Error
-Content-Type: application/json
+        $expectedHTTPVersion = '1.1';
+        $actualHTTPVersion = $response->getProtocolVersion();
 
-{"error":"Application Error"}
-HTML;
+        $expectedStatusCode = 500;
+        $actualStatusCode = $response->getStatusCode();
 
-        $this->assertSame($expected, (string) $response);
+        $expectedReasonPhrase = 'Internal Server Error';
+        $actualReasonPhrase = $response->getReasonPhrase();
+
+        $expectedHeaders = [
+            'Content-Type' => [
+                'application/json'
+            ]
+        ];
+        $actualHeaders = $response->getHeaders();
+
+        $expectedBody = '{"error":"Application Error"}';
+        $actualBody = $response->getBody();
+        $actualBody->rewind();
+
+        $this->assertSame($expectedHTTPVersion, $actualHTTPVersion);
+        $this->assertSame($expectedStatusCode, $actualStatusCode);
+        $this->assertSame($expectedReasonPhrase, $actualReasonPhrase);
+        $this->assertSame($expectedHeaders, $actualHeaders);
+        $this->assertSame($expectedBody, $actualBody->getContents());
     }
 }

--- a/tests/ErrorHandling/ContentHandler/PlainTextContentHandlerTest.php
+++ b/tests/ErrorHandling/ContentHandler/PlainTextContentHandlerTest.php
@@ -30,14 +30,31 @@ class PlainTextContentHandlerTest extends PHPUnit_Framework_TestCase
         $handler = new PlainTextContentHandler;
         $response = $handler->handleNotFound($this->request, $this->response);
 
-        $expected = <<<HTML
-HTTP/1.1 404 Not Found
-Content-Type: text/plain
+        $expectedHTTPVersion = '1.1';
+        $actualHTTPVersion = $response->getProtocolVersion();
 
-Not Found.
-HTML;
+        $expectedStatusCode = 404;
+        $actualStatusCode = $response->getStatusCode();
 
-        $this->assertSame($expected, (string) $response);
+        $expectedReasonPhrase = 'Not Found';
+        $actualReasonPhrase = $response->getReasonPhrase();
+
+        $expectedHeaders = [
+            'Content-Type' => [
+                'text/plain'
+            ]
+        ];
+        $actualHeaders = $response->getHeaders();
+
+        $expectedBody = 'Not Found.';
+        $actualBody = $response->getBody();
+        $actualBody->rewind();
+
+        $this->assertSame($expectedHTTPVersion, $actualHTTPVersion);
+        $this->assertSame($expectedStatusCode, $actualStatusCode);
+        $this->assertSame($expectedReasonPhrase, $actualReasonPhrase);
+        $this->assertSame($expectedHeaders, $actualHeaders);
+        $this->assertSame($expectedBody, $actualBody->getContents());
     }
 
     public function testNotAllowed()
@@ -45,15 +62,34 @@ HTML;
         $handler = new PlainTextContentHandler;
         $response = $handler->handleNotAllowed($this->request, $this->response, ['PATCH', 'STEVE']);
 
-        $expected = <<<HTML
-HTTP/1.1 405 Method Not Allowed
-Content-Type: text/plain
+        $expectedHTTPVersion = '1.1';
+        $actualHTTPVersion = $response->getProtocolVersion();
 
+        $expectedStatusCode = 405;
+        $actualStatusCode = $response->getStatusCode();
+
+        $expectedReasonPhrase = 'Method Not Allowed';
+        $actualReasonPhrase = $response->getReasonPhrase();
+
+        $expectedHeaders = [
+            'Content-Type' => [
+                'text/plain'
+            ]
+        ];
+        $actualHeaders = $response->getHeaders();
+
+        $expectedBody = <<<HTML
 Method not allowed.
 Allowed methods: PATCH, STEVE
 HTML;
+        $actualBody = $response->getBody();
+        $actualBody->rewind();
 
-        $this->assertSame($expected, (string) $response);
+        $this->assertSame($expectedHTTPVersion, $actualHTTPVersion);
+        $this->assertSame($expectedStatusCode, $actualStatusCode);
+        $this->assertSame($expectedReasonPhrase, $actualReasonPhrase);
+        $this->assertSame($expectedHeaders, $actualHeaders);
+        $this->assertSame($expectedBody, $actualBody->getContents());
     }
 
     public function testNotAllowedSets200StatusIfOptionsRequest()
@@ -63,15 +99,34 @@ HTML;
         $handler = new PlainTextContentHandler;
         $response = $handler->handleNotAllowed($this->request, $this->response, ['PATCH', 'STEVE']);
 
-        $expected = <<<HTML
-HTTP/1.1 200 OK
-Content-Type: text/plain
+        $expectedHTTPVersion = '1.1';
+        $actualHTTPVersion = $response->getProtocolVersion();
 
+        $expectedStatusCode = 200;
+        $actualStatusCode = $response->getStatusCode();
+
+        $expectedReasonPhrase = 'OK';
+        $actualReasonPhrase = $response->getReasonPhrase();
+
+        $expectedHeaders = [
+            'Content-Type' => [
+                'text/plain'
+            ]
+        ];
+        $actualHeaders = $response->getHeaders();
+
+        $expectedBody = <<<HTML
 Method not allowed.
 Allowed methods: PATCH, STEVE
 HTML;
+        $actualBody = $response->getBody();
+        $actualBody->rewind();
 
-        $this->assertSame($expected, (string) $response);
+        $this->assertSame($expectedHTTPVersion, $actualHTTPVersion);
+        $this->assertSame($expectedStatusCode, $actualStatusCode);
+        $this->assertSame($expectedReasonPhrase, $actualReasonPhrase);
+        $this->assertSame($expectedHeaders, $actualHeaders);
+        $this->assertSame($expectedBody, $actualBody->getContents());
     }
 
     public function testHandleException()
@@ -81,14 +136,31 @@ HTML;
         $handler = new PlainTextContentHandler;
         $response = $handler->handleException($this->request, $this->response, $ex);
 
-        $expected = <<<HTML
-HTTP/1.1 500 Internal Server Error
-Content-Type: text/plain
+        $expectedHTTPVersion = '1.1';
+        $actualHTTPVersion = $response->getProtocolVersion();
 
-Application Error
-HTML;
+        $expectedStatusCode = 500;
+        $actualStatusCode = $response->getStatusCode();
 
-        $this->assertSame($expected, (string) $response);
+        $expectedReasonPhrase = 'Internal Server Error';
+        $actualReasonPhrase = $response->getReasonPhrase();
+
+        $expectedHeaders = [
+            'Content-Type' => [
+                'text/plain'
+            ]
+        ];
+        $actualHeaders = $response->getHeaders();
+
+        $expectedBody = 'Application Error';
+        $actualBody = $response->getBody();
+        $actualBody->rewind();
+
+        $this->assertSame($expectedHTTPVersion, $actualHTTPVersion);
+        $this->assertSame($expectedStatusCode, $actualStatusCode);
+        $this->assertSame($expectedReasonPhrase, $actualReasonPhrase);
+        $this->assertSame($expectedHeaders, $actualHeaders);
+        $this->assertSame($expectedBody, $actualBody->getContents());
     }
 
     public function testHandleExceptionWithErrorDetails()
@@ -98,17 +170,36 @@ HTML;
         $handler = new PlainTextContentHandler(true);
         $response = $handler->handleException($this->request, $this->response, $ex);
 
-        $expected = <<<HTML
-HTTP/1.1 500 Internal Server Error
-Content-Type: text/plain
+        $expectedHTTPVersion = '1.1';
+        $actualHTTPVersion = $response->getProtocolVersion();
 
+        $expectedStatusCode = 500;
+        $actualStatusCode = $response->getStatusCode();
+
+        $expectedReasonPhrase = 'Internal Server Error';
+        $actualReasonPhrase = $response->getReasonPhrase();
+
+        $expectedHeaders = [
+            'Content-Type' => [
+                'text/plain'
+            ]
+        ];
+        $actualHeaders = $response->getHeaders();
+
+        $expectedBody = <<<HTML
 Application Error
 exception message
 HTML;
+        $actualBody = $response->getBody();
+        $actualBody->rewind();
+        $rendered = $actualBody->getContents();
 
-        $rendered = (string) $response;
-        $this->assertContains($expected, $rendered);
-        $this->assertContains('ErrorHandling/ContentHandler/PlainTextContentHandlerTest.php:96', $rendered);
+        $this->assertSame($expectedHTTPVersion, $actualHTTPVersion);
+        $this->assertSame($expectedStatusCode, $actualStatusCode);
+        $this->assertSame($expectedReasonPhrase, $actualReasonPhrase);
+        $this->assertSame($expectedHeaders, $actualHeaders);
+        $this->assertContains($expectedBody, $rendered);
+        $this->assertContains('ErrorHandling/ContentHandler/PlainTextContentHandlerTest.php:168', $rendered);
         $this->assertContains('Error Details:', $rendered);
     }
 }

--- a/tests/HTTP/NewBodyTraitTest.php
+++ b/tests/HTTP/NewBodyTraitTest.php
@@ -24,15 +24,27 @@ class NewBodyTraitTest extends PHPUnit_Framework_TestCase
     {
         $newBody = new NewBodyTraitStub;
         $output = $newBody->withNewBody($this->response, "data data\nmore data");
-        $expected = <<<'HTTP'
-HTTP/1.1 200 OK
 
+        $expectedHTTPVersion = '1.1';
+        $actualHTTPVersion = $output->getProtocolVersion();
+
+        $expectedStatusCode = 200;
+        $actualStatusCode = $output->getStatusCode();
+
+        $expectedReasonPhrase = 'OK';
+        $actualReasonPhrase = $output->getReasonPhrase();
+
+        $expectedBody = <<<'HTTP'
 data data
 more data
 HTTP;
+        $actualBody = $output->getBody();
+        $actualBody->rewind();
 
-        $this->assertSame($expected, (string) $output);
-
+        $this->assertSame($expectedHTTPVersion, $actualHTTPVersion);
+        $this->assertSame($expectedStatusCode, $actualStatusCode);
+        $this->assertSame($expectedReasonPhrase, $actualReasonPhrase);
+        $this->assertSame($expectedBody, $actualBody->getContents());
     }
 }
 

--- a/tests/HTTPProblem/ProblemRendereringTraitTest.php
+++ b/tests/HTTPProblem/ProblemRendereringTraitTest.php
@@ -32,15 +32,32 @@ class ProblemRendereringTraitTest extends PHPUnit_Framework_TestCase
 
         $rendering = new ProblemRenderingTraitStub;
         $output = $rendering->renderProblem($this->response, $this->renderer, $problem);
-        $expected = <<<'HTTP'
-HTTP/1.1 418 I'm a teapot
-Content-Type: application/problem+json
 
-{"status":418,"title":"I\u0027m a teapot","detail":"Something bad happened!","extra_context":"data1","test_extension":"data2"}
-HTTP;
+        $expectedHTTPVersion = '1.1';
+        $actualHTTPVersion = $output->getProtocolVersion();
 
-        $this->assertSame($expected, (string) $output);
+        $expectedStatusCode = 418;
+        $actualStatusCode = $output->getStatusCode();
 
+        $expectedReasonPhrase = 'I\'m a teapot';
+        $actualReasonPhrase = $output->getReasonPhrase();
+
+        $expectedHeaders = [
+            'Content-Type' => [
+                'application/problem+json'
+            ]
+        ];
+        $actualHeaders = $output->getHeaders();
+
+        $expectedBody = '{"status":418,"title":"I\u0027m a teapot","detail":"Something bad happened!","extra_context":"data1","test_extension":"data2"}';
+        $actualBody = $output->getBody();
+        $actualBody->rewind();
+
+        $this->assertSame($expectedHTTPVersion, $actualHTTPVersion);
+        $this->assertSame($expectedStatusCode, $actualStatusCode);
+        $this->assertSame($expectedReasonPhrase, $actualReasonPhrase);
+        $this->assertSame($expectedHeaders, $actualHeaders);
+        $this->assertSame($expectedBody, $actualBody->getContents());
     }
 }
 


### PR DESCRIPTION
This fixes a few HTTP tests that fail due to newline differences, by comparing individual pieces of the response object instead of one assertion with it cast to a string.