### PR TITLE
Updated .md docs to reflect configuration/config.yml change to config…

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ Never used Composer, Slim or Symfony before? Here are some resources:
 1. Create an application with the following file hiearchy:
 
    > ```
-   > configuration/
+   > config/
    >     bootstrap.php
-   >     config.yml
+   >     config.yaml
    >     di.yml
    >     routes.yml
    > public/
@@ -103,7 +103,7 @@ Never used Composer, Slim or Symfony before? Here are some resources:
    > }
    > ```
 
-3. `configuration/config.yml` should import other config resources.
+3. `config/config.yaml` should import other config resources.
 
     > ```yaml
     > imports:
@@ -116,7 +116,7 @@ Never used Composer, Slim or Symfony before? Here are some resources:
     >     env(PANTHOR_APPROOT): '/full/path/to/application' # We recommend using Symfony/Dotenv instead!
     > ```
 
-4. `configuration/di.yml` will contain service definitions for your application, such as controllers.
+4. `config/di.yml` will contain service definitions for your application, such as controllers.
 
     > ```yaml
     > services:
@@ -124,7 +124,7 @@ Never used Composer, Slim or Symfony before? Here are some resources:
     >         class: 'TestApplication\TestController'
     > ```
 
-5. `configuration/routes.yml` contains routes.
+5. `config/routes.yml` contains routes.
 
     > Routes is simply another config parameter passed into the DI container. It maps a route name to a url and list of
     > services to call.
@@ -136,7 +136,7 @@ Never used Composer, Slim or Symfony before? Here are some resources:
     >             stack: ['page.hello_world']
     > ```
 
-6. `configuration/bootstrap.php` should load the composer autoloader and return the DI container.
+6. `config/bootstrap.php` should load the composer autoloader and return the DI container.
 
     > ```php
     > <?php
@@ -162,7 +162,7 @@ Never used Composer, Slim or Symfony before? Here are some resources:
     >
     > namespace TestApplication\Bootstrap;
     >
-    > if (!$container = @include __DIR__ . '/../configuration/bootstrap.php') {
+    > if (!$container = @include __DIR__ . '/../config/bootstrap.php') {
     >     http_response_code(500);
     >     echo "The application failed to start.\n";
     >     exit;

--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -51,7 +51,7 @@ In included DI configuration has been split into two files:
 - `panthor-slim.yml` (Standard definitions for slim components)
 - `panthor.yml` (DI Definitions for panthor components and add-ons)
 
-If you use the included configs, include them in your `config.yml`:
+If you use the included configs, include them in your `config.yaml`:
 ```yaml
 imports:
     - resource: ../vendor/ql/mcp-panthor/configuration/panthor-slim.yml
@@ -163,7 +163,7 @@ And generate cached routes by running a script like so during your build process
 
 ```php
 $root = __DIR__;
-if (!$container = @include $root . '/configuration/bootstrap.php') {
+if (!$container = @include $root . '/config/bootstrap.php') {
     echo "An error occured while attempting to cache routes.\n";
     exit(1);
 };

--- a/docs/APPLICATION_STRUCTURE.md
+++ b/docs/APPLICATION_STRUCTURE.md
@@ -12,10 +12,10 @@ ROOT
 ├─ bin
 │   └─ executables
 │
-├─ configuration
+├─ config
 │   ├─ .env
 │   ├─ bootstrap.php
-│   ├─ config.yml
+│   ├─ config.yaml
 │   ├─ di.yml
 │   └─ routes.yml
 │
@@ -36,7 +36,7 @@ ROOT
        └─ ... tests
 ```
 
-#### configuration/
+#### config/
 
 The configuration directory contains all configuration files, usually in YAML.
 
@@ -79,7 +79,7 @@ to an environment, the matching file is found and merged into the general applic
 > return $container;
 > ```
 
-`config.yml`
+`config.yaml`
 > It is used for environment-independent configuration and is the common configuration file that loads all other
 > configuration. If you would like to break up your config or DI settings into multiple files to maintain your
 > sanity, just add them to the list of imports at the top of the file.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -38,9 +38,9 @@ controllers may implement, but no type checks are performed.
 #### Dependency Injection Configuration
 
 It is recommended applications import the panthor `panthor-slim.yml` and `panthor.yml` configuration files in their
-application `config.yml` file.
+application `config.yaml` file.
 
-Example `config.yml`:
+Example `config.yaml`:
 ```yaml
 imports:
     - resource: ../vendor/ql/mcp-panthor/configuration/panthor-slim.yml


### PR DESCRIPTION
Updated `README.md` and other '.md' docs to reflect [this change](https://github.com/quickenloans-mcp/mcp-panthor/commit/d5b1188c1e56f838558bbccf6c6c5f23fe80231b#diff-3722bcb11ed704faf824496e3bb72eafR22) to use `config/config.yaml` instead of `configuration/config.yml`