### PR TITLE
Panthor dependency update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ version: 2
 defaults: &defaults
     working_directory: '~/project'
     docker:
-        - 'image': 'halplatform/hal-build-environments:php5.6-centos7'
+        - 'image': 'halplatform/hal-build-environments:php7.2-centos7'
 
 matrix_defaults: &matrix_defaults
     working_directory: '~/project'
@@ -24,7 +24,7 @@ matrix_defaults: &matrix_defaults
         - run:
             name: 'Upload test coverage to Codacy (PHP 7.1 only)'
             command: |
-                if [ "${CIRCLE_JOB}" == "php7.1" ] ; then
+                if [ "${CIRCLE_JOB}" == "php7.2" ] ; then
                     ./vendor/bin/codacycoverage clover .phpunit/clover.xml
                 fi
 
@@ -38,13 +38,10 @@ workflows:
       - install:
           requires: [ fetch_code ]
 
-      - 'php5.6':
-          requires: [ install ]
-
-      - 'php7.0':
-          requires: [ install ]
-
       - 'php7.1':
+          requires: [ install ]
+
+      - 'php7.2':
           requires: [ install ]
 
 jobs:
@@ -83,17 +80,12 @@ jobs:
 
             - persist_to_workspace: { root: '.', paths: [ '.' ] }
 
-    'php5.6':
-        <<: *matrix_defaults
-        docker:
-            - 'image': 'halplatform/hal-build-environments:php5.6-centos7'
-
-    'php7.0':
-        <<: *matrix_defaults
-        docker:
-            - 'image': 'halplatform/hal-build-environments:php7.0-centos7'
-
     'php7.1':
         <<: *matrix_defaults
         docker:
             - 'image': 'halplatform/hal-build-environments:php7.1-centos7'
+
+    'php7.2':
+        <<: *matrix_defaults
+        docker:
+            - 'image': 'halplatform/hal-build-environments:php7.2-centos7'

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
 
     "require": {
-        "php": "~7.1.3",
+        "php": "^7.1.3",
 
         "acclimate/container": "~2.0.0",
         "dflydev/fig-cookies": "~1.0",

--- a/composer.json
+++ b/composer.json
@@ -19,33 +19,32 @@
     },
 
     "require": {
-        "php": "~5.6 || ~7.0",
+        "php": "~7.1",
 
-        "acclimate/container": "~1.0.0",
+        "acclimate/container": "~2.0.0",
         "dflydev/fig-cookies": "~1.0",
         "psr/http-message":    "~1.0",
         "psr/log":             "*",
-        "ql/mcp-common":       "~1.0",
-        "slim/slim":           "~3.4",
+        "ql/mcp-common":       "~2.0",
+        "slim/slim":           "~3.10",
 
-        "symfony/config":               "~3.3 || ~4.0",
-        "symfony/dependency-injection": "~3.3 || ~4.0",
-        "symfony/yaml":                 "~3.3 || ~4.0"
+        "symfony/config":               "~4.0",
+        "symfony/dependency-injection": "~4.0",
+        "symfony/yaml":                 "~4.0"
     },
 
     "require-dev": {
-        "mockery/mockery":      "~0.9",
-        "phpunit/phpunit":      "~5.6",
+        "mockery/mockery":      "~1.1",
+        "phpunit/phpunit":      "~6.5",
         "codacy/coverage":      "~1.4",
 
-        "ext-libsodium":           "~1.0",
-        "paragonie/random_compat": "~1.1",
+        "ext-sodium":           "~2.0 || ~7.2",
 
-        "symfony/proxy-manager-bridge": "~3.3 || ~4.0",
-        "twig/twig": "~1.27"
+        "symfony/proxy-manager-bridge": "~4.0",
+        "twig/twig": "~2.4"
     },
 
     "suggest": {
-        "ext-libsodium": "~1.0 || ~2.0 PECL Libsodium recommended for secure cookie encryption."
+        "ext-sodium": "~2.0 || ~7.2 Libsodium recommended for secure cookie encryption."
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
 
     "require": {
-        "php": "~7.1",
+        "php": "~7.1.3",
 
         "acclimate/container": "~2.0.0",
         "dflydev/fig-cookies": "~1.0",

--- a/configuration/panthor.yml
+++ b/configuration/panthor.yml
@@ -254,7 +254,7 @@ services:
         arguments: ['@router']
 
     panthor.clock:
-        class: 'QL\MCP\Common\Time\Clock'
+        class: 'QL\MCP\Common\Clock'
         arguments: ['now', '%panthor.internal.timezone%']
 
     panthor.json:

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,7 +9,7 @@
         convertWarningsToExceptions="true"
         forceCoversAnnotation="false"
         mapTestClassNameToCoveredClassName="true"
-        printerClass="PHPUnit_TextUI_ResultPrinter"
+        printerClass="PHPUnit\TextUI\ResultPrinter"
         processIsolation="false"
         stopOnError="true"
         stopOnFailure="true"

--- a/src/Bootstrap/DI.php
+++ b/src/Bootstrap/DI.php
@@ -64,17 +64,7 @@ class DI
             $container->loadFromExtension($ext->getAlias());
         }
 
-        foreach(static::DI_COMPILER_PASSES as $passClass => $options) {
-            if (!class_exists($passClass)) {
-                throw new RuntimeException("Symfony DI CompilerPass not found: \"${passClass}\"");
-            }
-
-            $pass = new $passClass;
-            $type = $options['type'] ?? PassConfig::TYPE_BEFORE_OPTIMIZATION;
-            $priority = $options['priority'] ?? 1000;
-
-            $container->addCompilerPass($pass, $type, $priority);
-        }
+        $container = static::addCompilerPasses($container);
 
         $container->compile($resolveEnvironment);
 
@@ -127,6 +117,29 @@ class DI
         }
 
         return $dumper->dump($config);
+    }
+
+    /**
+     * Adds compiler passes to container
+     *
+     * @param ContainerInterface $container
+     * @return void
+     */
+    private static function addCompilerPasses(ContainerInterface $container)
+    {
+        foreach(static::DI_COMPILER_PASSES as $passClass => $options) {
+            if (!class_exists($passClass)) {
+                throw new RuntimeException("Symfony DI CompilerPass not found: \"${passClass}\"");
+            }
+
+            $pass = new $passClass;
+            $type = $options['type'] ?? PassConfig::TYPE_BEFORE_OPTIMIZATION;
+            $priority = $options['priority'] ?? 1000;
+
+            $container->addCompilerPass($pass, $type, $priority);
+        }
+
+        return $container;
     }
 
     /**

--- a/src/Bootstrap/DI.php
+++ b/src/Bootstrap/DI.php
@@ -30,7 +30,9 @@ class DI
     const BUILD_AND_CACHE = false;
 
     const DI_EXTENSIONS = [];
-    const DI_COMPILER_PASSES = [PanthorCompilerPass::class => ['type' => PassConfig::TYPE_BEFORE_REMOVING, 'priority' => '1']];
+    const DI_COMPILER_PASSES = [
+        PanthorCompilerPass::class => ['type' => PassConfig::TYPE_BEFORE_REMOVING, 'priority' => '1']
+    ];
 
     /**
      * @param string $root
@@ -127,7 +129,7 @@ class DI
      */
     private static function addCompilerPasses(ContainerInterface $container)
     {
-        foreach(static::DI_COMPILER_PASSES as $passClass => $options) {
+        foreach (static::DI_COMPILER_PASSES as $passClass => $options) {
             if (!class_exists($passClass)) {
                 throw new RuntimeException("Symfony DI CompilerPass not found: \"${passClass}\"");
             }

--- a/src/Bootstrap/DependencyInjection/PanthorCompilerPass.php
+++ b/src/Bootstrap/DependencyInjection/PanthorCompilerPass.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * @copyright (c) 2018 Quicken Loans Inc.
+ *
+ * For full license information, please view the LICENSE distributed with this source code.
+ */
+
+namespace QL\Panthor\Bootstrap\DependencyInjection;
+
+use QL\Panthor\ControllerInterface;
+use QL\Panthor\MiddlewareInterface;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+
+class PanthorCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        $definitions = $container->getDefinitions();
+
+        foreach ($definitions as $definition) {
+            if (is_subclass_of($definition->getClass(), ControllerInterface::class)) {
+                $definition->setPublic(true);
+            }
+
+            if (is_subclass_of($definition->getClass(), MiddlewareInterface::class)) {
+                $definition->setPublic(true);
+            }
+        }
+    }
+}

--- a/src/Bootstrap/DependencyInjection/PanthorCompilerPass.php
+++ b/src/Bootstrap/DependencyInjection/PanthorCompilerPass.php
@@ -12,7 +12,6 @@ use QL\Panthor\MiddlewareInterface;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-
 class PanthorCompilerPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)

--- a/src/Encryption/LibsodiumSymmetricCrypto.php
+++ b/src/Encryption/LibsodiumSymmetricCrypto.php
@@ -60,11 +60,6 @@ class LibsodiumSymmetricCrypto
     private $authSecret;
 
     /**
-     * @var string
-     */
-    private $libsodiumInterface;
-
-    /**
      * $secret should each be a 128-character hexademical value.
      *
      * This will be broken into 2 64-character parts: crypto secret and auth secret.

--- a/src/Encryption/LibsodiumSymmetricCrypto.php
+++ b/src/Encryption/LibsodiumSymmetricCrypto.php
@@ -12,7 +12,7 @@ use QL\MCP\Common\Utility\ByteString;
 use QL\Panthor\Exception\CryptoException;
 
 /**
- * This uses libsodium encryption from Libsodium ~2.0
+ * This uses libsodium encryption from libsodium ~2.0
  *
  * @see https://pecl.php.net/package/libsodium
  * @see https://github.com/jedisct1/libsodium-php
@@ -29,7 +29,7 @@ class LibsodiumSymmetricCrypto
     /**
      * Setup errors
      */
-    const ERR_NEED_MORE_SALT = 'Libsodium extension is not installed. Please install "ext-libsodium" (<7.0) or "ext-sodium" (>=7.0).';
+    const ERR_NEED_MORE_SALT = 'Libsodium extension is not installed. Please install "ext-sodium" (>=7.0).';
     const ERR_CSPRNG = 'CSPRNG "random_bytes" not found. Please use PHP 7.0 or install paragonie/random_compat.';
     const ERR_INVALID_SECRET = 'Invalid encryption secret. Secret must be 128 hexadecimal characters.';
 
@@ -77,7 +77,9 @@ class LibsodiumSymmetricCrypto
      */
     public function __construct($secret)
     {
-        $this->libsodiumVersion = self::getSodiumVersion();
+        if (!extension_loaded('sodium')) {
+            throw new CryptoException(self::ERR_NEED_MORE_SALT);
+        }
 
         if (!function_exists(self::FQDN_RANDOMBYTES)) {
             throw new CryptoException(self::ERR_CSPRNG);
@@ -176,15 +178,7 @@ class LibsodiumSymmetricCrypto
      */
     private function sodiumHex2bin($var)
     {
-        if ($this->libsodiumVersion === '2' || $this->libsodiumVersion === '7') {
-            return \sodium_hex2bin($var);
-        }
-
-        if ($this->libsodiumVersion === '1') {
-            return \Sodium\hex2bin($var);
-        }
-
-        throw new CryptoException(self::ERR_NEED_MORE_SALT);
+        return \sodium_hex2bin($var);
     }
 
     /**
@@ -195,15 +189,7 @@ class LibsodiumSymmetricCrypto
      */
     public function sodiumCryptoAuth($message, $key)
     {
-        if ($this->libsodiumVersion === '2' || $this->libsodiumVersion === '7') {
-            return \sodium_crypto_auth($message, $key);
-        }
-
-        if ($this->libsodiumVersion === '1') {
-            return \Sodium\crypto_auth($message, $key);
-        }
-
-        throw new CryptoException(self::ERR_NEED_MORE_SALT);
+        return \sodium_crypto_auth($message, $key);
     }
 
     /**
@@ -211,15 +197,7 @@ class LibsodiumSymmetricCrypto
      */
     public function sodiumCryptoBytes()
     {
-        if ($this->libsodiumVersion === '2' || $this->libsodiumVersion === '7') {
-            return SODIUM_CRYPTO_AUTH_BYTES;
-        }
-
-        if ($this->libsodiumVersion === '1') {
-            return \Sodium\CRYPTO_AUTH_BYTES;
-        }
-
-        throw new CryptoException(self::ERR_NEED_MORE_SALT);
+        return SODIUM_CRYPTO_AUTH_BYTES;
     }
 
     /**
@@ -231,15 +209,7 @@ class LibsodiumSymmetricCrypto
      */
     public function sodiumCryptoAuthVerify($mac, $message, $key)
     {
-        if ($this->libsodiumVersion === '2' || $this->libsodiumVersion === '7') {
-            return \sodium_crypto_auth_verify($mac, $message, $key);
-        }
-
-        if ($this->libsodiumVersion === '1') {
-            return \Sodium\crypto_auth_verify($mac, $message, $key);
-        }
-
-        throw new CryptoException(self::ERR_NEED_MORE_SALT);
+        return \sodium_crypto_auth_verify($mac, $message, $key);
     }
 
     /**
@@ -251,15 +221,7 @@ class LibsodiumSymmetricCrypto
      */
     public function sodiumSecretBox($message, $nonce, $key)
     {
-        if ($this->libsodiumVersion === '2' || $this->libsodiumVersion === '7') {
-            return \sodium_crypto_secretbox($message, $nonce, $key);
-        }
-
-        if ($this->libsodiumVersion === '1') {
-            return \Sodium\crypto_secretbox($message, $nonce, $key);
-        }
-
-        throw new CryptoException(self::ERR_NEED_MORE_SALT);
+        return \sodium_crypto_secretbox($message, $nonce, $key);
     }
 
     /**
@@ -271,34 +233,6 @@ class LibsodiumSymmetricCrypto
      */
     public function sodiumSecretBoxOpen($message, $nonce, $key)
     {
-        if ($this->libsodiumVersion === '2'|| $this->libsodiumVersion === '7') {
-            return \sodium_crypto_secretbox_open($message, $nonce, $key);
-        }
-
-        if ($this->libsodiumVersion === '1') {
-            return \Sodium\crypto_secretbox_open($message, $nonce, $key);
-        }
-
-        throw new CryptoException(self::ERR_NEED_MORE_SALT);
-    }
-
-    /**
-     * @return string
-     */
-    public static function getSodiumVersion()
-    {
-        $php71orLower = phpversion('libsodium');
-        $php7orGreater = phpversion('sodium');
-
-        if ($php7orGreater !== false) {
-            return substr($php7orGreater, 0, 1);
-        }
-
-        if ($php71orLower !== false) {
-            return substr($php71orLower, 0, 1);
-        }
-
-        // uh oh not installed!
-        throw new CryptoException(self::ERR_NEED_MORE_SALT);
+        return \sodium_crypto_secretbox_open($message, $nonce, $key);
     }
 }

--- a/src/Encryption/LibsodiumSymmetricCrypto.php
+++ b/src/Encryption/LibsodiumSymmetricCrypto.php
@@ -12,7 +12,7 @@ use QL\MCP\Common\Utility\ByteString;
 use QL\Panthor\Exception\CryptoException;
 
 /**
- * This uses libsodium encryption from Libsodium ~1.0 or Libsodium ~2.0
+ * This uses libsodium encryption from Libsodium ~2.0
  *
  * @see https://pecl.php.net/package/libsodium
  * @see https://github.com/jedisct1/libsodium-php
@@ -176,7 +176,7 @@ class LibsodiumSymmetricCrypto
      */
     private function sodiumHex2bin($var)
     {
-        if ($this->libsodiumVersion === '2') {
+        if ($this->libsodiumVersion === '2' || $this->libsodiumVersion === '7') {
             return \sodium_hex2bin($var);
         }
 
@@ -195,7 +195,7 @@ class LibsodiumSymmetricCrypto
      */
     public function sodiumCryptoAuth($message, $key)
     {
-        if ($this->libsodiumVersion === '2') {
+        if ($this->libsodiumVersion === '2' || $this->libsodiumVersion === '7') {
             return \sodium_crypto_auth($message, $key);
         }
 
@@ -211,7 +211,7 @@ class LibsodiumSymmetricCrypto
      */
     public function sodiumCryptoBytes()
     {
-        if ($this->libsodiumVersion === '2') {
+        if ($this->libsodiumVersion === '2' || $this->libsodiumVersion === '7') {
             return SODIUM_CRYPTO_AUTH_BYTES;
         }
 
@@ -231,7 +231,7 @@ class LibsodiumSymmetricCrypto
      */
     public function sodiumCryptoAuthVerify($mac, $message, $key)
     {
-        if ($this->libsodiumVersion === '2') {
+        if ($this->libsodiumVersion === '2' || $this->libsodiumVersion === '7') {
             return \sodium_crypto_auth_verify($mac, $message, $key);
         }
 
@@ -251,7 +251,7 @@ class LibsodiumSymmetricCrypto
      */
     public function sodiumSecretBox($message, $nonce, $key)
     {
-        if ($this->libsodiumVersion === '2') {
+        if ($this->libsodiumVersion === '2' || $this->libsodiumVersion === '7') {
             return \sodium_crypto_secretbox($message, $nonce, $key);
         }
 
@@ -271,7 +271,7 @@ class LibsodiumSymmetricCrypto
      */
     public function sodiumSecretBoxOpen($message, $nonce, $key)
     {
-        if ($this->libsodiumVersion === '2') {
+        if ($this->libsodiumVersion === '2'|| $this->libsodiumVersion === '7') {
             return \sodium_crypto_secretbox_open($message, $nonce, $key);
         }
 

--- a/src/Testing/MockeryAssistantTrait.php
+++ b/src/Testing/MockeryAssistantTrait.php
@@ -8,9 +8,12 @@
 namespace QL\Panthor\Testing;
 
 use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 
 trait MockeryAssistantTrait
 {
+    use MockeryPHPUnitIntegration;
+
     private $spies;
 
     /**

--- a/src/Twig/TwigExtension.php
+++ b/src/Twig/TwigExtension.php
@@ -9,7 +9,7 @@ namespace QL\Panthor\Twig;
 
 use DateTime;
 use DateTimeZone;
-use QL\MCP\Common\Time\Clock;
+use QL\MCP\Common\Clock;
 use QL\MCP\Common\Time\TimePoint;
 use QL\Panthor\Utility\URI;
 use Twig_Extension;

--- a/tests/Bootstrap/CacheableRouterTest.php
+++ b/tests/Bootstrap/CacheableRouterTest.php
@@ -7,9 +7,9 @@
 
 namespace QL\Panthor\Bootstrap;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class CacheableRouterTest extends PHPUnit_Framework_TestCase
+class CacheableRouterTest extends TestCase
 {
     public $cacheFile;
 
@@ -55,20 +55,23 @@ class CacheableRouterTest extends PHPUnit_Framework_TestCase
 
         $expected = <<<'ROUTE_FILE'
 <?php return array (
-  0 => 
+  0 =>
   array (
-    'GET' => 
+    'GET' =>
     array (
       '/page' => 'route0',
     ),
   ),
-  1 => 
+  1 =>
   array (
   ),
 );
 ROUTE_FILE;
 
         $this->assertFileExists($this->cacheFile);
-        $this->assertEquals($expected, file_get_contents($this->cacheFile));
+        $expected = preg_replace('/[\n ]/', '', $expected);
+        $actual = file_get_contents($this->cacheFile);
+        $actual = preg_replace('/[\n ]/', '', $actual);;
+        $this->assertEquals($expected, $actual);
     }
 }

--- a/tests/Bootstrap/DITest.php
+++ b/tests/Bootstrap/DITest.php
@@ -7,10 +7,10 @@
 
 namespace QL\Panthor\Bootstrap;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
-class DITest extends PHPUnit_Framework_TestCase
+class DITest extends TestCase
 {
     public $root;
 

--- a/tests/Bootstrap/GlobalMiddlewareLoaderTest.php
+++ b/tests/Bootstrap/GlobalMiddlewareLoaderTest.php
@@ -9,13 +9,16 @@ namespace QL\Panthor\Bootstrap;
 
 use InvalidArgumentException;
 use Mockery;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use QL\Panthor\Exception\Exception;
 use Slim\App;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 
-class GlobalMiddlewareLoaderTest extends PHPUnit_Framework_TestCase
+class GlobalMiddlewareLoaderTest extends TestCase
 {
+    use MockeryPHPUnitIntegration;
+
     public function testMiddlewareIsAttached()
     {
         $middlewares = [

--- a/tests/Bootstrap/RouteLoaderTest.php
+++ b/tests/Bootstrap/RouteLoaderTest.php
@@ -7,11 +7,11 @@
 
 namespace QL\Panthor\Bootstrap;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Slim\App;
 use Slim\RouteGroup;
 
-class RouteLoaderTest extends PHPUnit_Framework_TestCase
+class RouteLoaderTest extends TestCase
 {
     public $slim;
 

--- a/tests/Encryption/LibsodiumSymmetricCryptoTest.php
+++ b/tests/Encryption/LibsodiumSymmetricCryptoTest.php
@@ -7,10 +7,10 @@
 
 namespace QL\Panthor\Encryption;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use stdClass;
 
-class LibsodiumSymmetricCryptoTest extends PHPUnit_Framework_TestCase
+class LibsodiumSymmetricCryptoTest extends TestCase
 {
     private $secret;
 

--- a/tests/ErrorHandling/ContentHandler/HTMLTemplateContentHandlerTest.php
+++ b/tests/ErrorHandling/ContentHandler/HTMLTemplateContentHandlerTest.php
@@ -9,14 +9,14 @@ namespace QL\Panthor\ErrorHandling\ContentHandler;
 
 use ErrorException;
 use Mockery;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use QL\Panthor\TemplateInterface;
 use QL\Panthor\Testing\MockeryAssistantTrait;
 use Slim\Http\Environment;
 use Slim\Http\Request;
 use Slim\Http\Response;
 
-class HTMLTemplateContentHandlerTest extends PHPUnit_Framework_TestCase
+class HTMLTemplateContentHandlerTest extends TestCase
 {
     use MockeryAssistantTrait;
 

--- a/tests/ErrorHandling/ContentHandler/HTTPProblemContentHandlerTest.php
+++ b/tests/ErrorHandling/ContentHandler/HTTPProblemContentHandlerTest.php
@@ -9,12 +9,12 @@ namespace QL\Panthor\ErrorHandling\ContentHandler;
 
 use ErrorException;
 use Mockery;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Slim\Http\Environment;
 use Slim\Http\Request;
 use Slim\Http\Response;
 
-class HTTPProblemContentHandlerTest extends PHPUnit_Framework_TestCase
+class HTTPProblemContentHandlerTest extends TestCase
 {
     private $request;
     private $response;

--- a/tests/ErrorHandling/ContentHandler/JSONContentHandlerTest.php
+++ b/tests/ErrorHandling/ContentHandler/JSONContentHandlerTest.php
@@ -9,12 +9,12 @@ namespace QL\Panthor\ErrorHandling\ContentHandler;
 
 use ErrorException;
 use Mockery;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Slim\Http\Environment;
 use Slim\Http\Request;
 use Slim\Http\Response;
 
-class JSONContentHandlerTest extends PHPUnit_Framework_TestCase
+class JSONContentHandlerTest extends TestCase
 {
     private $request;
     private $response;

--- a/tests/ErrorHandling/ContentHandler/LoggingContentHandlerTest.php
+++ b/tests/ErrorHandling/ContentHandler/LoggingContentHandlerTest.php
@@ -9,13 +9,15 @@ namespace QL\Panthor\ErrorHandling\ContentHandler;
 
 use ErrorException;
 use Mockery;
-use PHPUnit_Framework_TestCase;
-use QL\MCP\Common\Testing\MemoryLogger;
+use PHPUnit\Framework\TestCase;
 use Slim\Http\Environment;
 use Slim\Http\Request;
 use Slim\Http\Response;
+use QL\MCP\Logger\MemoryLogger;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LoggerTrait;
 
-class LoggingContentHandlerTest extends PHPUnit_Framework_TestCase
+class LoggingContentHandlerTest extends TestCase
 {
     private $request;
     private $response;
@@ -26,7 +28,28 @@ class LoggingContentHandlerTest extends PHPUnit_Framework_TestCase
     {
         $this->request = Request::createFromEnvironment(Environment::mock());
         $this->response = new Response;
-        $this->logger = new MemoryLogger;
+
+        //Because I can
+        $this->logger = new class() implements LoggerInterface {
+            use LoggerTrait;
+
+            public $messages = [];
+            /**
+             * @param mixed $level
+             * @param string $message
+             * @param array $context
+             * @return null
+             */
+            public function log($level, $message, array $context = [])
+            {
+                $this->messages[] = [
+                    'level' => $level,
+                    'message' => $message,
+                    'context' => $context
+                ];
+            }
+        };
+
         $this->config = [
             'error' => 'critical',
             'not-allowed' => 'info',

--- a/tests/ErrorHandling/ContentHandler/NegotiatingContentHandlerTest.php
+++ b/tests/ErrorHandling/ContentHandler/NegotiatingContentHandlerTest.php
@@ -9,12 +9,12 @@ namespace QL\Panthor\ErrorHandling\ContentHandler;
 
 use ErrorException;
 use Mockery;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Slim\Http\Environment;
 use Slim\Http\Request;
 use Slim\Http\Response;
 
-class NegotiatingContentHandlerTest extends PHPUnit_Framework_TestCase
+class NegotiatingContentHandlerTest extends TestCase
 {
     private $request;
     private $response;

--- a/tests/ErrorHandling/ContentHandler/PlainTextContentHandlerTest.php
+++ b/tests/ErrorHandling/ContentHandler/PlainTextContentHandlerTest.php
@@ -9,12 +9,12 @@ namespace QL\Panthor\ErrorHandling\ContentHandler;
 
 use ErrorException;
 use Mockery;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Slim\Http\Environment;
 use Slim\Http\Request;
 use Slim\Http\Response;
 
-class PlainTextContentHandlerTest extends PHPUnit_Framework_TestCase
+class PlainTextContentHandlerTest extends TestCase
 {
     private $request;
     private $response;

--- a/tests/ErrorHandling/ErrorHandlerTest.php
+++ b/tests/ErrorHandling/ErrorHandlerTest.php
@@ -9,13 +9,13 @@ namespace QL\Panthor\ErrorHandling;
 
 use ErrorException;
 use Mockery;
-use PHPUnit_Framework_TestCase;
-use QL\MCP\Common\Testing\MemoryLogger;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use QL\Panthor\Exception\Exception;
 use QL\Panthor\Testing\MockeryAssistantTrait;
 use Slim\App;
 
-class ErrorHandlerTest extends PHPUnit_Framework_TestCase
+class ErrorHandlerTest extends TestCase
 {
     use MockeryAssistantTrait;
 
@@ -92,16 +92,14 @@ class ErrorHandlerTest extends PHPUnit_Framework_TestCase
 
     public function testLoggableErrorIsLoggedIfNotThrown()
     {
-        $logger = new MemoryLogger;
+        $logger = Mockery::mock(LoggerInterface::class);
         $handler = new ErrorHandler($this->exHandler, $logger);
         $handler->setThrownErrors(\E_NOTICE);
         $handler->setLoggedErrors(\E_DEPRECATED);
 
-        $isHandled = $handler->handleError(\E_DEPRECATED, 'error message', 'filename.php', '80');
+        $logger->shouldReceive('log')->with(Mockery::any(), 'Deprecated: error message', Mockery::any());
 
-        $this->assertSame(true, $isHandled);
-        $this->assertCount(1, $logger->messages);
-        $this->assertSame('Deprecated: error message', $logger->messages[0]['message']);
+        $isHandled = $handler->handleError(\E_DEPRECATED, 'error message', 'filename.php', '80');
     }
 
     public function testErrorSeverityType()

--- a/tests/ErrorHandling/ExceptionHandlerTest.php
+++ b/tests/ErrorHandling/ExceptionHandlerTest.php
@@ -9,15 +9,18 @@ namespace QL\Panthor\ErrorHandling;
 
 use ErrorException;
 use Mockery;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use QL\Panthor\Exception\Exception;
 use Slim\App;
 use Slim\Http\Environment;
 use Slim\Http\Request;
 use Slim\Http\Response;
+use QL\Panthor\Testing\MockeryAssistantTrait;
 
-class ExceptionHandlerTest extends PHPUnit_Framework_TestCase
+class ExceptionHandlerTest extends TestCase
 {
+    use MockeryAssistantTrait;
+
     private $request;
     private $response;
     private $contentHandler;

--- a/tests/HTTP/CookieEncryption/LibsodiumCookieEncryptionTest.php
+++ b/tests/HTTP/CookieEncryption/LibsodiumCookieEncryptionTest.php
@@ -8,12 +8,15 @@
 namespace QL\Panthor\HTTP\CookieEncryption;
 
 use Mockery;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use QL\Panthor\Encryption\LibsodiumSymmetricCrypto;
 use QL\Panthor\Exception\CryptoException;
+use QL\Panthor\Testing\MockeryAssistantTrait;
 
-class LibsodiumCookieEncryptionTest extends PHPUnit_Framework_TestCase
+class LibsodiumCookieEncryptionTest extends TestCase
 {
+    use MockeryAssistantTrait;
+
     public $crypto;
     public $binaryData;
 

--- a/tests/HTTP/CookieHandlerTest.php
+++ b/tests/HTTP/CookieHandlerTest.php
@@ -10,14 +10,14 @@ namespace QL\Panthor\HTTP;
 use Dflydev\FigCookies\Cookie;
 use Dflydev\FigCookies\Cookies;
 use Mockery;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use QL\MCP\Common\OpaqueProperty;
 use QL\Panthor\Exception\Exception;
 use Slim\Http\Environment;
 use Slim\Http\Request;
 use Slim\Http\Response;
 
-class CookieHandlerTest extends PHPUnit_Framework_TestCase
+class CookieHandlerTest extends TestCase
 {
     private $request;
     private $reponse;
@@ -30,7 +30,8 @@ class CookieHandlerTest extends PHPUnit_Framework_TestCase
 
     public function testBadExpiresCookieConfiguration()
     {
-        $this->setExpectedException(Exception::class, CookieHandler::ERR_BAD_EXPIRES);
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage(CookieHandler::ERR_BAD_EXPIRES);
 
         new CookieHandler([
             'expires' => ['bad-value']
@@ -39,7 +40,8 @@ class CookieHandlerTest extends PHPUnit_Framework_TestCase
 
     public function testBadSecureCookieConfiguration()
     {
-        $this->setExpectedException(Exception::class, CookieHandler::ERR_BAD_SECURE);
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage(CookieHandler::ERR_BAD_SECURE);
 
         new CookieHandler([
             'secure' => ['bad-value']
@@ -48,7 +50,8 @@ class CookieHandlerTest extends PHPUnit_Framework_TestCase
 
     public function testBadHttpOnlyCookieConfiguration()
     {
-        $this->setExpectedException(Exception::class, CookieHandler::ERR_BAD_HTTP);
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage(CookieHandler::ERR_BAD_HTTP);
 
         new CookieHandler([
             'httpOnly' => ['bad-value']

--- a/tests/HTTP/NewBodyTraitTest.php
+++ b/tests/HTTP/NewBodyTraitTest.php
@@ -8,10 +8,10 @@
 namespace QL\Panthor\HTTP;
 
 use Mockery;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Slim\Http\Response;
 
-class NewBodyTraitTest extends PHPUnit_Framework_TestCase
+class NewBodyTraitTest extends TestCase
 {
     public $response;
 

--- a/tests/HTTPProblem/HTTPProblemTest.php
+++ b/tests/HTTPProblem/HTTPProblemTest.php
@@ -7,9 +7,9 @@
 
 namespace QL\Panthor\HTTPProblem;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class HTTPProblemTest extends PHPUnit_Framework_TestCase
+class HTTPProblemTest extends TestCase
 {
     public function testMinimumValidProblem()
     {

--- a/tests/HTTPProblem/ProblemRendereringTraitTest.php
+++ b/tests/HTTPProblem/ProblemRendereringTraitTest.php
@@ -8,11 +8,11 @@
 namespace QL\Panthor\HTTPProblem;
 
 use Mockery;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use QL\Panthor\HTTPProblem\Renderer\JSONRenderer;
 use Slim\Http\Response;
 
-class ProblemRendereringTraitTest extends PHPUnit_Framework_TestCase
+class ProblemRendereringTraitTest extends TestCase
 {
     public $response;
     public $renderer;

--- a/tests/HTTPProblem/Renderer/JSONRendererTest.php
+++ b/tests/HTTPProblem/Renderer/JSONRendererTest.php
@@ -7,11 +7,11 @@
 
 namespace QL\Panthor\HTTPProblem\Renderer;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use QL\Panthor\HTTPProblem\HTTPProblem;
 use QL\Panthor\Utility\JSON;
 
-class JSONRendererTest extends PHPUnit_Framework_TestCase
+class JSONRendererTest extends TestCase
 {
     public function testOptionalPropertiesNotRendered()
     {

--- a/tests/Middleware/EncryptedCookiesMiddlewareTest.php
+++ b/tests/Middleware/EncryptedCookiesMiddlewareTest.php
@@ -10,15 +10,18 @@ namespace QL\Panthor\Middleware;
 use Dflydev\FigCookies\Cookies;
 use Dflydev\FigCookies\SetCookie;
 use Mockery;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use QL\MCP\Common\OpaqueProperty;
 use QL\Panthor\HTTP\CookieEncryptionInterface;
 use Slim\Http\Environment;
 use Slim\Http\Request;
 use Slim\Http\Response;
+use QL\Panthor\Testing\MockeryAssistantTrait;
 
-class EncryptedCookiesMiddlewareTest extends PHPUnit_Framework_TestCase
+class EncryptedCookiesMiddlewareTest extends TestCase
 {
+    use MockeryAssistantTrait;
+
     private $encryption;
 
     private $request;

--- a/tests/Middleware/SessionMiddlewareTest.php
+++ b/tests/Middleware/SessionMiddlewareTest.php
@@ -8,15 +8,18 @@
 namespace QL\Panthor\Middleware;
 
 use Mockery;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use QL\Panthor\HTTP\CookieHandler;
 use QL\Panthor\Session\SessionInterface;
 use Slim\Http\Environment;
 use Slim\Http\Request;
 use Slim\Http\Response;
+use QL\Panthor\Testing\MockeryAssistantTrait;
 
-class SessionMiddlewareTest extends PHPUnit_Framework_TestCase
+class SessionMiddlewareTest extends TestCase
 {
+    use MockeryAssistantTrait;
+
     private $handler;
 
     private $request;

--- a/tests/Session/JSONEncodedTest.php
+++ b/tests/Session/JSONEncodedTest.php
@@ -8,9 +8,9 @@
 namespace QL\Panthor\Session;
 
 use Mockery;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class JSONEncodedSessionTest extends PHPUnit_Framework_TestCase
+class JSONEncodedSessionTest extends TestCase
 {
     public function testAccessors()
     {

--- a/tests/SymfonyIntegrationTest.php
+++ b/tests/SymfonyIntegrationTest.php
@@ -7,12 +7,12 @@
 
 namespace QL\Panthor;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\Config\FileLocator;
 
-class SymfonyIntegrationTest extends PHPUnit_Framework_TestCase
+class SymfonyIntegrationTest extends TestCase
 {
     public function testContainerCompiles()
     {

--- a/tests/Templating/NullTemplateTest.php
+++ b/tests/Templating/NullTemplateTest.php
@@ -7,9 +7,9 @@
 
 namespace QL\Panthor\Templating;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class NullTemplateTest extends PHPUnit_Framework_TestCase
+class NullTemplateTest extends TestCase
 {
     public function testNullTemplateRendersEmptyString()
     {

--- a/tests/Templating/TwigTemplateTest.php
+++ b/tests/Templating/TwigTemplateTest.php
@@ -8,12 +8,12 @@
 namespace QL\Panthor\Templating;
 
 use Mockery;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use QL\Panthor\Twig\Context;
 use Twig_Environment;
 use Twig_Loader_Array;
 
-class TwigTemplateTest extends PHPUnit_Framework_TestCase
+class TwigTemplateTest extends TestCase
 {
     public $twig;
 

--- a/tests/Twig/ContextTest.php
+++ b/tests/Twig/ContextTest.php
@@ -7,9 +7,9 @@
 
 namespace QL\Panthor\Twig;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class ContextTest extends PHPUnit_Framework_TestCase
+class ContextTest extends TestCase
 {
     public function testInitiallyLoadedContext()
     {

--- a/tests/Twig/LazyTwigTest.php
+++ b/tests/Twig/LazyTwigTest.php
@@ -8,10 +8,13 @@
 namespace QL\Panthor\Twig;
 
 use Mockery;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
+use QL\Panthor\Testing\MockeryAssistantTrait;
 
-class LazyTwigTest extends PHPUnit_Framework_TestCase
+class LazyTwigTest extends TestCase
 {
+    use MockeryAssistantTrait;
+
     /**
      * @expectedException InvalidArgumentException
      */

--- a/tests/Twig/TwigExtensionTest.php
+++ b/tests/Twig/TwigExtensionTest.php
@@ -11,7 +11,7 @@ use DateTime;
 use DateTimeZone;
 use Mockery;
 use PHPUnit\Framework\TestCase;
-use QL\MCP\Common\Time\Clock;
+use QL\MCP\Common\Clock;
 use QL\MCP\Common\Time\TimePoint;
 use QL\Panthor\Utility\URI;
 use stdClass;

--- a/tests/Twig/TwigExtensionTest.php
+++ b/tests/Twig/TwigExtensionTest.php
@@ -10,14 +10,17 @@ namespace QL\Panthor\Twig;
 use DateTime;
 use DateTimeZone;
 use Mockery;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use QL\MCP\Common\Time\Clock;
 use QL\MCP\Common\Time\TimePoint;
 use QL\Panthor\Utility\URI;
 use stdClass;
+use QL\Panthor\Testing\MockeryAssistantTrait;
 
-class TwigExtensionTest extends PHPUnit_Framework_TestCase
+class TwigExtensionTest extends TestCase
 {
+    use MockeryAssistantTrait;
+
     public $uri;
     public $clock;
 

--- a/tests/Utility/ClosureFactoryTest.php
+++ b/tests/Utility/ClosureFactoryTest.php
@@ -7,14 +7,15 @@
 
 namespace QL\Panthor\Utility;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use QL\Panthor\Exception\Exception;
 
-class ClosureFactoryTest extends PHPUnit_Framework_TestCase
+class ClosureFactoryTest extends TestCase
 {
     public function testNonCallableThrowsException()
     {
-        $this->setExpectedException(Exception::class, 'Invalid callable provided.');
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Invalid callable provided.');
 
         ClosureFactory::buildClosure('that', 'this');
     }

--- a/tests/Utility/JSONTest.php
+++ b/tests/Utility/JSONTest.php
@@ -7,10 +7,10 @@
 
 namespace QL\Panthor\Utility;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use stdClass;
 
-class JSONTest extends PHPUnit_Framework_TestCase
+class JSONTest extends TestCase
 {
     public function testEncoding()
     {

--- a/tests/Utility/StringifyTest.php
+++ b/tests/Utility/StringifyTest.php
@@ -7,9 +7,9 @@
 
 namespace QL\Panthor\Utility;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class StringifyTest extends PHPUnit_Framework_TestCase
+class StringifyTest extends TestCase
 {
     public function testTemplate()
     {

--- a/tests/Utility/URITest.php
+++ b/tests/Utility/URITest.php
@@ -8,12 +8,15 @@
 namespace QL\Panthor\Utility;
 
 use Mockery;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Slim\Http\Uri as SlimUri;
 use Slim\Router;
+use QL\Panthor\Testing\MockeryAssistantTrait;
 
-class URITest extends PHPUnit_Framework_TestCase
+class URITest extends TestCase
 {
+    use MockeryAssistantTrait;
+
     private $router;
 
     public function setUp()
@@ -71,4 +74,3 @@ class URITest extends PHPUnit_Framework_TestCase
         $this->assertSame('http://host:8443/test-route-page', $actual);
     }
 }
-


### PR DESCRIPTION
This PR simply bumps dependency versions and fixes any unit tests or namespaces that broke from that. 

It sets the stage for making bigger changes around symfony 4.0 components like auto setting route services to public, auto configuring twig templates for controllers, and anything else that would go into a new release.