### PR TITLE
Allow libsodiumVersion 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,6 @@
         "phpunit/phpunit":      "~5.6",
         "codacy/coverage":      "~1.4",
 
-        "ext-libsodium":           "~1.0",
         "paragonie/random_compat": "~1.1",
 
         "symfony/proxy-manager-bridge": "~3.3 || ~4.0",
@@ -46,6 +45,7 @@
     },
 
     "suggest": {
-        "ext-libsodium": "~1.0 || ~2.0 PECL Libsodium recommended for secure cookie encryption."
+        "ext-libsodium": "~1.0 || ~2.0 PECL Libsodium recommended for secure cookie encryption.",
+        "ext-sodium": "~2.0 || ~7.2 Libsodium recommended for secure cookie encryption."
     }
 }

--- a/src/Encryption/LibsodiumSymmetricCrypto.php
+++ b/src/Encryption/LibsodiumSymmetricCrypto.php
@@ -176,7 +176,7 @@ class LibsodiumSymmetricCrypto
      */
     private function sodiumHex2bin($var)
     {
-        if ($this->libsodiumVersion === '2') {
+        if ($this->libsodiumVersion === '2' || $this->libsodiumVersion === '7') {
             return \sodium_hex2bin($var);
         }
 
@@ -195,7 +195,7 @@ class LibsodiumSymmetricCrypto
      */
     public function sodiumCryptoAuth($message, $key)
     {
-        if ($this->libsodiumVersion === '2') {
+        if ($this->libsodiumVersion === '2' || $this->libsodiumVersion === '7') {
             return \sodium_crypto_auth($message, $key);
         }
 
@@ -211,7 +211,7 @@ class LibsodiumSymmetricCrypto
      */
     public function sodiumCryptoBytes()
     {
-        if ($this->libsodiumVersion === '2') {
+        if ($this->libsodiumVersion === '2' || $this->libsodiumVersion === '7') {
             return SODIUM_CRYPTO_AUTH_BYTES;
         }
 
@@ -231,7 +231,7 @@ class LibsodiumSymmetricCrypto
      */
     public function sodiumCryptoAuthVerify($mac, $message, $key)
     {
-        if ($this->libsodiumVersion === '2') {
+        if ($this->libsodiumVersion === '2' || $this->libsodiumVersion === '7') {
             return \sodium_crypto_auth_verify($mac, $message, $key);
         }
 
@@ -251,7 +251,7 @@ class LibsodiumSymmetricCrypto
      */
     public function sodiumSecretBox($message, $nonce, $key)
     {
-        if ($this->libsodiumVersion === '2') {
+        if ($this->libsodiumVersion === '2' || $this->libsodiumVersion === '7') {
             return \sodium_crypto_secretbox($message, $nonce, $key);
         }
 
@@ -271,7 +271,7 @@ class LibsodiumSymmetricCrypto
      */
     public function sodiumSecretBoxOpen($message, $nonce, $key)
     {
-        if ($this->libsodiumVersion === '2') {
+        if ($this->libsodiumVersion === '2' || $this->libsodiumVersion === '7') {
             return \sodium_crypto_secretbox_open($message, $nonce, $key);
         }
 


### PR DESCRIPTION
This modifies `LibsodiumSymmetricCrypto` to accept Libsodium version 7 in addition to 1 and 2, thereby adding support for PHP 7.2